### PR TITLE
Apply upstream patch to PollingWatchService for AIX

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -61,6 +61,10 @@ import java.util.concurrent.TimeUnit;
 class PollingWatchService
     extends AbstractWatchService
 {
+    // Wait between polling thread creation and first poll (seconds)
+    private static final int POLLING_INIT_DELAY = 1;
+    // Default time between polls (seconds)
+    private static final int DEFAULT_POLLING_INTERVAL = 2;
     // map of registrations
     private final Map<Object, PollingWatchKey> map = new HashMap<>();
 
@@ -115,7 +119,7 @@ class PollingWatchService
             throw new IllegalArgumentException("No events to register");
 
         // Extended modifiers may be used to specify the sensitivity level
-        int sensitivity = 10;
+        int sensitivity = DEFAULT_POLLING_INTERVAL;
         if (modifiers.length > 0) {
             for (WatchEvent.Modifier modifier: modifiers) {
                 if (modifier == null)
@@ -305,10 +309,10 @@ class PollingWatchService
                 // update the events
                 this.events = events;
 
-                // create the periodic task
+                // create the periodic task with initialDelay set to the specified constant
                 Runnable thunk = new Runnable() { public void run() { poll(); }};
                 this.poller = scheduledExecutor
-                    .scheduleAtFixedRate(thunk, period, period, TimeUnit.SECONDS);
+                    .scheduleAtFixedRate(thunk, POLLING_INIT_DELAY, period, TimeUnit.SECONDS);
             }
         }
 


### PR DESCRIPTION
This pulls in the patch from https://github.com/adoptium/jdk/commit/1bb4de2e2868a539846ec48dd43fd623c2ba69a5 to address an issue in the file system watch capability which has not yet been backported to JDK17 and 18.