### PR TITLE
Backport PR11665 - (fs) Change PollingWatchService to record last modified time as FileTime rather than milliseconds

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -29,13 +29,13 @@ import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
@@ -51,6 +51,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 /**
  * Simple WatchService implementation that uses periodic tasks to poll
@@ -224,10 +225,10 @@ class PollingWatchService
      * Entry in directory cache to record file last-modified-time and tick-count
      */
     private static class CacheEntry {
-        private long lastModified;
+        private FileTime lastModified;
         private int lastTickCount;
 
-        CacheEntry(long lastModified, int lastTickCount) {
+        CacheEntry(FileTime lastModified, int lastTickCount) {
             this.lastModified = lastModified;
             this.lastTickCount = lastTickCount;
         }
@@ -236,11 +237,11 @@ class PollingWatchService
             return lastTickCount;
         }
 
-        long lastModified() {
+        FileTime lastModified() {
             return lastModified;
         }
 
-        void update(long lastModified, int tickCount) {
+        void update(FileTime lastModified, int tickCount) {
             this.lastModified = lastModified;
             this.lastTickCount = tickCount;
         }
@@ -283,8 +284,7 @@ class PollingWatchService
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
                 for (Path entry: stream) {
                     // don't follow links
-                    long lastModified =
-                        Files.getLastModifiedTime(entry, LinkOption.NOFOLLOW_LINKS).toMillis();
+                    FileTime lastModified = Files.getLastModifiedTime(entry, NOFOLLOW_LINKS);
                     entries.put(entry.getFileName(), new CacheEntry(lastModified, tickCount));
                 }
             } catch (DirectoryIteratorException e) {
@@ -361,10 +361,9 @@ class PollingWatchService
             // iterate over all entries in directory
             try {
                 for (Path entry: stream) {
-                    long lastModified = 0L;
+                    FileTime lastModified;
                     try {
-                        lastModified =
-                            Files.getLastModifiedTime(entry, LinkOption.NOFOLLOW_LINKS).toMillis();
+                        lastModified = Files.getLastModifiedTime(entry, NOFOLLOW_LINKS);
                     } catch (IOException x) {
                         // unable to get attributes of entry. If file has just
                         // been deleted then we'll report it as deleted on the
@@ -376,8 +375,7 @@ class PollingWatchService
                     CacheEntry e = entries.get(entry.getFileName());
                     if (e == null) {
                         // new file found
-                        entries.put(entry.getFileName(),
-                                     new CacheEntry(lastModified, tickCount));
+                        entries.put(entry.getFileName(), new CacheEntry(lastModified, tickCount));
 
                         // queue ENTRY_CREATE if event enabled
                         if (events.contains(StandardWatchEventKinds.ENTRY_CREATE)) {
@@ -396,7 +394,7 @@ class PollingWatchService
                     }
 
                     // check if file has changed
-                    if (e.lastModified != lastModified) {
+                    if (!e.lastModified().equals(lastModified)) {
                         if (events.contains(StandardWatchEventKinds.ENTRY_MODIFY)) {
                             signalEvent(StandardWatchEventKinds.ENTRY_MODIFY,
                                         entry.getFileName());


### PR DESCRIPTION
https://github.com/adoptium/jdk17u/pull/5/commits/eacac28b361947d7504134b0ccd2e23ebd603286 was in the dev branch https://github.com/adoptium/jdk17u/pull/5, but it is also required on the release branch to get into the January release.